### PR TITLE
Update device.js

### DIFF
--- a/www/device.js
+++ b/www/device.js
@@ -54,7 +54,7 @@ function Device() {
             me.version = info.version;
             me.uuid = info.uuid;
             me.cordova = buildLabel;
-            me.model = info.model;
+            me.model = info.model || info.name;
             channel.onCordovaInfoReady.fire();
         },function(e) {
             me.available = false;


### PR DESCRIPTION
On windows 8 tablets eg. HP ElitePad, the device model is returned to the info object in the name attribute (info.name). info.model doesn't even exist in info object.
