### PR TITLE
CB-5105 (Removed dead code for device.version)

### DIFF
--- a/src/android/Device.java
+++ b/src/android/Device.java
@@ -33,7 +33,6 @@ import android.provider.Settings;
 public class Device extends CordovaPlugin {
     public static final String TAG = "Device";
 
-    public static String cordovaVersion = "dev";              // Cordova version
     public static String platform;                            // Device OS
     public static String uuid;                                // Device UUID
 
@@ -73,7 +72,6 @@ public class Device extends CordovaPlugin {
             r.put("uuid", Device.uuid);
             r.put("version", this.getOSVersion());
             r.put("platform", this.getPlatform());
-            r.put("cordova", Device.cordovaVersion);
             r.put("model", this.getModel());
             callbackContext.success(r);
         }
@@ -110,15 +108,6 @@ public class Device extends CordovaPlugin {
     public String getUuid() {
         String uuid = Settings.Secure.getString(this.cordova.getActivity().getContentResolver(), android.provider.Settings.Secure.ANDROID_ID);
         return uuid;
-    }
-
-    /**
-     * Get the Cordova version.
-     *
-     * @return
-     */
-    public String getCordovaVersion() {
-        return Device.cordovaVersion;
     }
 
     public String getModel() {

--- a/src/blackberry10/index.js
+++ b/src/blackberry10/index.js
@@ -60,8 +60,7 @@ module.exports = {
                 platform: "blackberry10",
                 version: window.qnx.webplatform.device.scmBundle,
                 model: modelName,
-                uuid: uuid,
-                cordova: "dev"
+                uuid: uuid
             };
 
         result.ok(info);

--- a/src/windows8/DeviceProxy.js
+++ b/src/windows8/DeviceProxy.js
@@ -40,7 +40,7 @@ module.exports = {
         }
 
         setTimeout(function () {
-            win({ platform: "windows8", version: "8", uuid: deviceId, cordova: '0.0.0', model: window.clientInformation.platform });
+            win({ platform: "windows8", version: "8", uuid: deviceId, model: window.clientInformation.platform });
         }, 0);
     }
 

--- a/src/wp/Device.cs
+++ b/src/wp/Device.cs
@@ -35,16 +35,13 @@ namespace WPCordovaClassLib.Cordova.Commands
         public void getDeviceInfo(string notused)
         {
 
-            string res = String.Format("\"name\":\"{0}\",\"cordova\":\"{1}\",\"platform\":\"{2}\",\"uuid\":\"{3}\",\"version\":\"{4}\",\"model\":\"{5}\"",
+            string res = String.Format("\"name\":\"{0}\",\"platform\":\"{1}\",\"uuid\":\"{2}\",\"version\":\"{3}\",\"model\":\"{4}\"",
                                         this.name,
-                                        this.cordova,
                                         this.platform,
                                         this.uuid,
                                         this.version,
                                         this.model);
-
-
-
+										
             res = "{" + res + "}";
             //Debug.WriteLine("Result::" + res);
             DispatchCommandResult(new PluginResult(PluginResult.Status.OK, res));
@@ -65,15 +62,6 @@ namespace WPCordovaClassLib.Cordova.Commands
             {
                 return DeviceStatus.DeviceName;
                 
-            }
-        }
-
-        public string cordova
-        {
-            get
-            {
-                // TODO: should be able to dynamically read the Cordova version from somewhere...
-                return "3.0.0";
             }
         }
 


### PR DESCRIPTION
Dead code has been removed from the native side for the following
platforms:

-Android
-WP8
-BB10
-Windows 8
Every variable, method or argument related with retrieve the cordova
version from the native side has been removed. Given the fact that
cordova.js, it's providing the cordova.version.

The plugin has been tested under each platform involved with the
expected results, everything settled to be added to the repository.
