### PR TITLE
[CB-6422] Use cordova/exec/proxy instead of platform dupes

### DIFF
--- a/src/firefoxos/DeviceProxy.js
+++ b/src/firefoxos/DeviceProxy.js
@@ -77,4 +77,4 @@ module.exports = {
     }
 };
 
-require("cordova/firefoxos/commandProxy").add("Device", module.exports);
+require("cordova/exec/proxy").add("Device", module.exports);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-6422
[CB-6422] Use cordova/exec/proxy instead of platform dupes
