### PR TITLE
adds new property 'manufacturer' for Android (and hardcoded for iOS, Blackberry)

### DIFF
--- a/src/android/Device.java
+++ b/src/android/Device.java
@@ -73,6 +73,7 @@ public class Device extends CordovaPlugin {
             r.put("version", this.getOSVersion());
             r.put("platform", this.getPlatform());
             r.put("model", this.getModel());
+            r.put("manufacturer", this.getManufacturer());
             callbackContext.success(r);
         }
         else {
@@ -120,6 +121,10 @@ public class Device extends CordovaPlugin {
         return productname;
     }
 
+    public String getManufacturer() {
+        String manufacturer = android.os.Build.MANUFACTURER;
+        return manufacturer;
+    }
     /**
      * Get the OS version.
      *

--- a/src/blackberry10/index.js
+++ b/src/blackberry10/index.js
@@ -57,7 +57,7 @@ module.exports = {
             modelName = getModelName(),
             uuid = getUUID(),
             info = {
-                manufacturer: 'Research in Motion',
+                manufacturer: 'BlackBerry',
                 platform: "blackberry10",
                 version: window.qnx.webplatform.device.scmBundle,
                 model: modelName,

--- a/src/blackberry10/index.js
+++ b/src/blackberry10/index.js
@@ -57,6 +57,7 @@ module.exports = {
             modelName = getModelName(),
             uuid = getUUID(),
             info = {
+                manufacturer: 'Research in Motion',
                 platform: "blackberry10",
                 version: window.qnx.webplatform.device.scmBundle,
                 model: modelName,

--- a/src/ios/CDVDevice.m
+++ b/src/ios/CDVDevice.m
@@ -72,6 +72,7 @@
     UIDevice* device = [UIDevice currentDevice];
     NSMutableDictionary* devProps = [NSMutableDictionary dictionaryWithCapacity:4];
 
+    [devProps setObject:@"Apple" forKey:@"manufacturer"];
     [devProps setObject:[device modelVersion] forKey:@"model"];
     [devProps setObject:@"iOS" forKey:@"platform"];
     [devProps setObject:[device systemVersion] forKey:@"version"];

--- a/www/device.js
+++ b/www/device.js
@@ -41,6 +41,7 @@ function Device() {
     this.uuid = null;
     this.cordova = null;
     this.model = null;
+    this.manufacturer = null;
 
     var me = this;
 
@@ -55,6 +56,7 @@ function Device() {
             me.uuid = info.uuid;
             me.cordova = buildLabel;
             me.model = info.model;
+            me.manufacturer = info.manufacturer || 'unknown';
             channel.onCordovaInfoReady.fire();
         },function(e) {
             me.available = false;


### PR DESCRIPTION
For some platforms it makes sense to be able to list the Manufacturer for a device. These changes allow retrieval of manufacturer name for Android, iOS & Blackberry. Have not added to other platforms as I have no access to those or know the API's.