### PR TITLE
[fxos] Remove cordova version

### DIFF
--- a/src/firefoxos/DeviceProxy.js
+++ b/src/firefoxos/DeviceProxy.js
@@ -67,7 +67,6 @@ module.exports = {
     getDeviceInfo: function (success, error) {
         setTimeout(function () {
             success({
-                cordova: firefoxos.cordovaVersion,
                 platform: 'firefoxos',
                 model: getModel(),
                 version: getVersion(),


### PR DESCRIPTION
It's unused after [CB-5105](https://issues.apache.org/jira/browse/CB-5105).
