### PR TITLE
Request to change the device.platform to always report the browser platform as "browser".

### DIFF
--- a/src/browser/DeviceProxy.js
+++ b/src/browser/DeviceProxy.js
@@ -22,7 +22,7 @@ var browser = require('cordova/platform');
 var cordova = require('cordova');
 
 function getPlatform() {
-    return navigator.platform;
+    return "browser";
 }
 
 function getModel() {


### PR DESCRIPTION
The current Browser platform implementation relies on the value returned by the web browser's `navigator.platform`, which has many possible values, making platform-specific checks difficult. For example, a Browser platform build viewed on an Android device might report the `device.platform` as "Android", causing the Cordova app to execute code intended for the Android platform, instead of the desired code intended for the Browser platform.
