### PR TITLE
Don't fail completely if device plugin is not present

### DIFF
--- a/src/browser/DeviceProxy.js
+++ b/src/browser/DeviceProxy.js
@@ -22,7 +22,7 @@ var browser = require('cordova/platform');
 var cordova = require('cordova');
 
 function getPlatform() {
-    return navigator.platform;
+    return "browser";
 }
 
 function getModel() {

--- a/www/device.js
+++ b/www/device.js
@@ -58,9 +58,10 @@ function Device() {
             channel.onCordovaInfoReady.fire();
         },function(e) {
             me.available = false;
-            if (console && console.log) {
-              console.log("[ERROR] Error initializing Cordova Device Plugin: " + e);
+            if (console && console.error) {
+              console.error("[ERROR] Error initializing Cordova Device Plugin: " + e);
             }
+            channel.onCordovaInfoReady.fire();
         });
     });
 }

--- a/www/device.js
+++ b/www/device.js
@@ -58,7 +58,9 @@ function Device() {
             channel.onCordovaInfoReady.fire();
         },function(e) {
             me.available = false;
-            utils.alert("[ERROR] Error initializing Cordova: " + e);
+            if (console && console.log) {
+              console.log("[ERROR] Error initializing Cordova Device Plugin: " + e);
+            }
         });
     });
 }


### PR DESCRIPTION
* Removed `util.alert` and opted for `console.error` as `util.alert` will call `window.alert`, degrading experience for the user on the device.
* Fire `onCordovaInfoReady` even if loading the `device` plugin failed. This way the entire Cordova app is not broken for one plugin.