### PR TITLE
Internet Explorer browser support

### DIFF
--- a/src/browser/DeviceProxy.js
+++ b/src/browser/DeviceProxy.js
@@ -35,7 +35,7 @@ function getVersion() {
 
 function getBrowserInfo(getModel) {
     var userAgent = navigator.userAgent;
-    var returnVal;
+    var returnVal = '';
 
     if ((offset = userAgent.indexOf('Chrome')) !== -1) {
         returnVal = (getModel) ? 'Chrome' : userAgent.substring(offset + 7);
@@ -51,6 +51,10 @@ function getBrowserInfo(getModel) {
         }
     } else if ((offset = userAgent.indexOf('Firefox')) !== -1) {
         returnVal = (getModel) ? 'Firefox' : userAgent.substring(offset + 8);
+    } else if ((offset = userAgent.indexOf('MSIE')) !== -1) {
+        returnVal = (getModel) ? 'MSIE' : userAgent.substring(offset + 5);
+    } else if ((offset = userAgent.indexOf('Trident')) !== -1) {
+        returnVal = (getModel) ? 'MSIE' : '11';
     }
 
     if ((offset = returnVal.indexOf(';')) !== -1 || (offset = returnVal.indexOf(' ')) !== -1) {


### PR DESCRIPTION
Added support for Internet Explorer and other browsers when using the new "browser" platform in Cordova 4.

Chrome, Safari, and Firefox were already supported, but when using IE or any other browser an error would occur because the user agent string wasn't recognized.

I added specific logic to parse Internet Explorer's user agent string.  Note that IE 11's user agent string doesn't include "MSIE", so I search for "Trident" as well.

I also fixed the bug that was causing an error if the user agent wasn't recognized, so if a browser other than Chrome, Safari, Firefox, or IE is used, the plugin will still work.  It just won't have the `device.model` or `device.version` set.