### PR TITLE
CB-9505 Makes DeviceProxy accessible in browserified bundle

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -141,7 +141,7 @@
     <!-- windows -->
     <platform name="windows">
         <js-module src="src/windows/DeviceProxy.js" name="DeviceProxy">
-            <merges target="" />
+            <runs />
         </js-module>
     </platform>
 


### PR DESCRIPTION
This fixes https://issues.apache.org/jira/browse/CB-9505