### PR TITLE
Feature add is simulator for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Get the operating system version.
     // iPhone:     iOS 3.2 returns "3.2"
     //
     // Windows Phone 7: returns current OS version number, ex. on Mango returns 7.10.7720
+    // Windows 8: return the current OS version, ex on Windows 8.1 returns 6.3.9600.16384
     // Tizen: returns "TIZEN_20120425_2"
     var deviceVersion = device.version;
 
@@ -228,6 +229,7 @@ whether the device is running on a simulator.
 - Android 2.1+
 - iOS
 - Windows Phone 8
+- Windows 8
 
 
 ## device.serial

--- a/www/device.js
+++ b/www/device.js
@@ -58,7 +58,7 @@ function Device() {
             me.uuid = info.uuid;
             me.cordova = buildLabel;
             me.model = info.model;
-	        me.isVirtual = info.isVirtual;
+            me.isVirtual = info.isVirtual;
             me.manufacturer = info.manufacturer || 'unknown';
             me.serial = info.serial || 'unknown';
             channel.onCordovaInfoReady.fire();


### PR DESCRIPTION
This adds the `isVirtual` for the Windows 8.x Desktop and Phone platforms.
Virtual means the app is running in the Windows Simulator (a remote session) or the Windows Phone/Mobile Emulator.

I also simplified the retrieval of the device manufacture name by using `Windows.Security.ExchangeActiveSyncProvisioning.EasClientDeviceInformation`