### PR TITLE
CB-10631 ios: Fix for device.uuid in iOS 5.1.1

### DIFF
--- a/src/ios/CDVDevice.m
+++ b/src/ios/CDVDevice.m
@@ -55,7 +55,12 @@
     // which didn't user identifierForVendor
     NSString* app_uuid = [userDefaults stringForKey:UUID_KEY];
     if (app_uuid == nil) {
-        app_uuid = [[device identifierForVendor] UUIDString];
+        if ([[UIDevice currentDevice] respondsToSelector:@selector(identifierForVendor)]) {
+            app_uuid = [[device identifierForVendor] UUIDString];
+        } else {
+            app_uuid = (__bridge NSString *) CFUUIDCreateString(NULL, CFUUIDCreate(NULL));
+        }
+
         [userDefaults setObject:app_uuid forKey:UUID_KEY];
         [userDefaults synchronize];
     }


### PR DESCRIPTION
- Check if identifierForVendor exists and if not create a new UUID
  and store in on the device for future use.