### PR TITLE
CB-12105 (browser) Properly detect Edge

### DIFF
--- a/src/browser/DeviceProxy.js
+++ b/src/browser/DeviceProxy.js
@@ -37,7 +37,9 @@ function getBrowserInfo(getModel) {
     var returnVal = '';
     var offset;
 
-    if ((offset = userAgent.indexOf('Chrome')) !== -1) {
+    if ((offset = userAgent.indexOf('Edge')) !== -1) {
+        returnVal = (getModel) ? 'Edge' : userAgent.substring(offset + 5);
+    } else if ((offset = userAgent.indexOf('Chrome')) !== -1) {
         returnVal = (getModel) ? 'Chrome' : userAgent.substring(offset + 7);
     } else if ((offset = userAgent.indexOf('Safari')) !== -1) {
         if (getModel) {


### PR DESCRIPTION
### Platforms affected
Browser

### What does this PR do?
Allows the plugin to properly detect Edge browser.
https://issues.apache.org/jira/browse/CB-12105

### What testing has been done on this change?
Tested on Edge 38, Chrome 56, Firefox 51

### Checklist
- [x] [Reported an issue](https://issues.apache.org/jira/browse/CB-12105) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
