### PR TITLE
fix(android)!: access Context through webView.getContext() (CB-12623)

### DIFF
--- a/src/android/Device.java
+++ b/src/android/Device.java
@@ -109,7 +109,7 @@ public class Device extends CordovaPlugin {
      * @return
      */
     public String getUuid() {
-        String uuid = Settings.Secure.getString(this.cordova.getActivity().getContentResolver(), android.provider.Settings.Secure.ANDROID_ID);
+        String uuid = Settings.Secure.getString(this.cordova.getContext().getContentResolver(), android.provider.Settings.Secure.ANDROID_ID);
         return uuid;
     }
 


### PR DESCRIPTION
Android WebView can be created without an Activity. One use case is
to create a WebView within a Service and attach/detach it to an
Activity window on demand.
