### PR TITLE
CB-12935: (windows) Enable paramedic builds on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,28 @@
+# appveyor file
+# http://www.appveyor.com/docs/appveyor-yml
+
+max_jobs: 1
+
+shallow_clone: true
+
+init:
+  - git config --global core.autocrlf true
+
+image:
+  - Visual Studio 2017
+
+environment:
+  nodejs_version: "4"
+  matrix:
+    - PLATFORM: windows-10-store
+
+install:
+  - npm cache clean -f
+  - node --version
+  - npm install -g cordova-paramedic@https://github.com/apache/cordova-paramedic.git
+  - npm install -g cordova
+
+build: off
+
+test_script:
+  - cordova-paramedic --config pr\%PLATFORM% --plugin . --justBuild


### PR DESCRIPTION
### Platforms affected
Windows

### What does this PR do?
https://issues.apache.org/jira/browse/CB-12935
Enables AppVeyor build

### What testing has been done on this change?
See the build!

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
