### PR TITLE
CB-13113 (browser) device.isVirtual is always false

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,14 +287,15 @@ var isSim = device.isVirtual;
 ### Supported Platforms
 
 - Android 2.1+
+- Browser
 - iOS
 - Windows Phone 8
 - Windows
 - OSX
 
-### OSX Quirk
+### OSX and Browser Quirk
 
-The `isVirtual` property on OS X always returns false.
+The `isVirtual` property on OS X and Browser always returns false.
 
 ## device.serial
 

--- a/src/browser/DeviceProxy.js
+++ b/src/browser/DeviceProxy.js
@@ -75,7 +75,8 @@ module.exports = {
                 platform: getPlatform(),
                 model: getModel(),
                 version: getVersion(),
-                uuid: null
+                uuid: null,
+                isVirtual: false
             });
         }, 0);
     }


### PR DESCRIPTION
### Platforms affected
Browser

### What does this PR do?
Introduces device.isVirtual to browser platform and makes it always equal `false`

### What testing has been done on this change?
an automated test run on browser platform

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
