### PR TITLE
CB-13893: (ios) delete libz.tbd from device plugin

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -55,8 +55,6 @@
 
         <header-file src="src/ios/CDVDevice.h" />
         <source-file src="src/ios/CDVDevice.m" />
-
-		<framework src="libz.tbd" />
     </platform>
 
     <!-- windows -->


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
ios

### What does this PR do?
removes libz.tbd as it's not needed

### What testing has been done on this change?
tested on ios 9 and ios 11 devices

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
