### PR TITLE
CB-14106m - device.model is different on simulator and on real device

### DIFF
--- a/src/ios/CDVDevice.m
+++ b/src/ios/CDVDevice.m
@@ -28,6 +28,9 @@
 
 - (NSString*)modelVersion
 {
+#if TARGET_IPHONE_SIMULATOR
+    NSString* platform = NSProcessInfo.processInfo.environment[@"SIMULATOR_MODEL_IDENTIFIER"];
+#else
     size_t size;
 
     sysctlbyname("hw.machine", NULL, &size, NULL, 0);
@@ -35,7 +38,7 @@
     sysctlbyname("hw.machine", machine, &size, NULL, 0);
     NSString* platform = [NSString stringWithUTF8String:machine];
     free(machine);
-
+#endif
     return platform;
 }
 


### PR DESCRIPTION
(ios) using correct device.model on simulator

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?


### What testing has been done on this change?


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
