### PR TITLE
fix(android): Fix Samsung mobile device serial issue

### DIFF
--- a/src/android/Device.java
+++ b/src/android/Device.java
@@ -30,6 +30,9 @@ import org.json.JSONObject;
 
 import android.provider.Settings;
 
+import java.lang.reflect.Method;
+import android.os.Build;
+
 public class Device extends CordovaPlugin {
     public static final String TAG = "Device";
 
@@ -129,8 +132,45 @@ public class Device extends CordovaPlugin {
     }
 
     public String getSerialNumber() {
-        String serial = android.os.Build.SERIAL;
-        return serial;
+       String serialNumber;
+        try {
+            Class<?> c = Class.forName("android.os.SystemProperties");
+            Method get = c.getMethod("get", String.class);
+            // (?) Lenovo Tab (https://stackoverflow.com/a/34819027/1276306)
+            serialNumber = (String) get.invoke(c, "gsm.sn1");
+            if (serialNumber.equals(""))
+                // Samsung Galaxy S5 (SM-G900F) : 6.0.1
+                // Samsung Galaxy S6 (SM-G920F) : 7.0
+                // Samsung Galaxy Tab 4 (SM-T530) : 5.0.2
+                // (?) Samsung Galaxy Tab 2 (https://gist.github.com/jgold6/f46b1c049a1ee94fdb52)
+                serialNumber = (String) get.invoke(c, "ril.serialnumber");
+
+            if (serialNumber.equals(""))
+                // Archos 133 Oxygen : 6.0.1
+                // Google Nexus 5 : 6.0.1
+                // Hannspree HANNSPAD 13.3" TITAN 2 (HSG1351) : 5.1.1
+                // Honor 5C (NEM-L51) : 7.0
+                // Honor 5X (KIW-L21) : 6.0.1
+                // Huawei M2 (M2-801w) : 5.1.1
+                // (?) HTC Nexus One : 2.3.4 (https://gist.github.com/tetsu-koba/992373)
+                serialNumber = (String) get.invoke(c, "ro.serialno");
+
+            if (serialNumber.equals(""))
+                // (?) Samsung Galaxy Tab 3 (https://stackoverflow.com/a/27274950/1276306)
+                serialNumber = (String) get.invoke(c, "sys.serialnumber");
+
+            if (serialNumber.equals(""))
+                // Archos 133 Oxygen : 6.0.1
+                // Hannspree HANNSPAD 13.3" TITAN 2 (HSG1351) : 5.1.1
+                // Honor 9 Lite (LLD-L31) : 8.0
+                // Xiaomi Mi 8 (M1803E1A) : 8.1.0
+                serialNumber = Build.SERIAL;
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            serialNumber = null;
+        }
+        return serialNumber;
     }
 
     /**


### PR DESCRIPTION
### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Few Samsung devices are not returning an actual result. I have added a few more method to get the device serial number so that the user can get their expected result. It can solve the below issue : 
https://github.com/apache/cordova-plugin-device/issues/91

### Description
<!-- Describe your changes in detail -->
I have created a function that will solve the Samsung device serial issue as well other since I have added a few more cases according to their Manufacture and it's typed.


### Testing
<!-- Please describe in detail how you tested your changes. -->
I have checked it in a few Samsung Android devices. Before this, it's not working properly but now I am getting the actual result.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
