### PR TITLE
Log error to console, not to dialog box

### DIFF
--- a/www/device.js
+++ b/www/device.js
@@ -64,7 +64,7 @@ function Device () {
             channel.onCordovaInfoReady.fire();
         }, function (e) {
             me.available = false;
-            utils.alert('[ERROR] Error initializing Cordova: ' + e);
+            console.error('[ERROR] Error initializing cordova-plugin-device: ' + e);
         });
     });
 }

--- a/www/device.js
+++ b/www/device.js
@@ -21,7 +21,6 @@
 
 var argscheck = require('cordova/argscheck');
 var channel = require('cordova/channel');
-var utils = require('cordova/utils');
 var exec = require('cordova/exec');
 var cordova = require('cordova');
 


### PR DESCRIPTION
### Platforms affected
All


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Presenting an error to a user in an alert box is bad UX. And it's annoying as a developer too.
Plus, I'd like to deprecate `cordova/utils.alert` and this is the only occurrence in a core plugin.


### Description
<!-- Describe your changes in detail -->
- log error to console instead of using alert
- clarify origin of error message


### Testing
<!-- Please describe in detail how you tested your changes. -->
None
