### PR TITLE
#113 (browser) - Properly detect new Edge Chromium version as Edge instead of Chrome

### DIFF
--- a/src/browser/DeviceProxy.js
+++ b/src/browser/DeviceProxy.js
@@ -37,8 +37,16 @@ function getBrowserInfo (getModel) {
     var returnVal = '';
     var offset;
 
-    if ((offset = userAgent.indexOf('Edge')) !== -1) {
-        returnVal = (getModel) ? 'Edge' : userAgent.substring(offset + 5);
+    if ((offset = userAgent.indexOf('Edg')) !== -1) {
+        if (getModel) {
+            returnVal = 'Edge';
+        } else {
+            if ((offset = userAgent.indexOf('Edge')) !== -1) {
+                returnVal = userAgent.substring(offset + 5);
+            } else {
+                returnVal = userAgent.substring(offset + 4);
+            }
+        }
     } else if ((offset = userAgent.indexOf('Chrome')) !== -1) {
         returnVal = (getModel) ? 'Chrome' : userAgent.substring(offset + 7);
     } else if ((offset = userAgent.indexOf('Safari')) !== -1) {


### PR DESCRIPTION
### Platforms affected
browser

### Motivation and Context
Allows the plugin to properly detect the new Edge browser based on Chromium.
https://github.com/apache/cordova-plugin-device/issues/113


### Description
The new Chromium based Edge browser exposed the following `userAgent`:
```
Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36 Edg/79.0.309.54
```
This change detects the browser as Edge instead of Chrome. And pulls the correct version.

### Testing
On Edge and on Edge Chromium based execture the plugin and get the model and version

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary

Closes #113 