### PR TITLE
ci(appveyor): adds x64 build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,6 +16,10 @@ environment:
     - nodejs_version: "10"
     - nodejs_version: "12"
 
+platform:
+  - x86
+  - x64
+
 install:
   - ps: Install-Product node $env:nodejs_version
   - node --version


### PR DESCRIPTION
This aligns the repo with the other plugins - most of them have x64 and x86 tests.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
