### PR TITLE
GH-91 android: Implement the changes in getting serial (Api_level 26):

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -37,9 +37,13 @@
     <!-- android -->
     <platform name="android">
         <config-file target="res/xml/config.xml" parent="/*">
-            <feature name="Device" >
+            <feature name="Device">
                 <param name="android-package" value="org.apache.cordova.device.Device"/>
             </feature>
+        </config-file>
+        <config-file target="AndroidManifest.xml" parent="/*">
+            <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
+            <uses-permission android:name="android.permission.READ_PRIVILEGED_PHONE_STATE"/>
         </config-file>
 
         <source-file src="src/android/Device.java" target-dir="src/org/apache/cordova/device" />

--- a/src/android/Device.java
+++ b/src/android/Device.java
@@ -129,7 +129,14 @@ public class Device extends CordovaPlugin {
     }
 
     public String getSerialNumber() {
-        String serial = android.os.Build.SERIAL;
+        String serial;
+        int sdk_int = android.os.Build.VERSION.SDK_INT;
+        if (sdk_int < 26) {
+          serial = android.os.Build.SERIAL;
+        }
+        else {
+          serial = android.os.Build.getSerial();
+        }
         return serial;
     }
 


### PR DESCRIPTION
    * get the serial according to the Api_level:
        + if Api_level < 26:
          => android.os.Build.SERIAL (deprecated in Api_level 26)
        + else:
          => serial = android.os.Build.getSerial(); (introduced in 26)
    * add the appropriate permissions:
        + READ_PHONE_STATE
        + READ_PRIVILEGED_PHONE_STATE

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
 * Android (only)


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The android 9 introduced some changes in reading crucial device info (https://developer.android.com/about/versions/pie/android-9.0-changes-28), so to get the serial number of a device, you must use getSeial method instead of the 'SERIAL' constante (whoch is depricated), you need also the following permissions
        * READ_PHONE_STATE
        * READ_PRIVILEGED_PHONE_STATE 



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
