### PR TITLE
feat(ios): detect if app is running on a macOS desktop with Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,8 +264,8 @@ var string = device.serial;
 
 ## device.isiOSAppOnMac
 
-Is the iOS app running on the Mac desktop? Will only return true on a Mac with an ARM64 processor (Apple Silicon).
-Returns false for all other platforms.
+The iOS app is running on the Mac desktop (Apple Silicon ARM64 processor, M1 or newer). 
+This parameter is only returned for iOS V14.0 or later, and is not returned for Android devices.
 
 ```js
 var boolean = device.isiOSAppOnMac;

--- a/README.md
+++ b/README.md
@@ -262,6 +262,10 @@ var string = device.serial;
 - Android
 - OSX
 
+### Android Quirk
+
+As of Android 9, the underlying native API that powered the `uuid` property is deprecated and will always return `UNKNOWN` without proper permissions. Cordova have never implemented handling the required permissions. As of Android 10, **all** non-resettable device identifiers are no longer readable by normal applications and will always return `UNKNOWN`. More information can be [read here](https://developer.android.com/about/versions/10/privacy/changes#non-resettable-device-ids).
+
 ## device.isiOSAppOnMac
 
 The iOS app is running on the Mac desktop (Apple Silicon ARM64 processor, M1 or newer). 

--- a/README.md
+++ b/README.md
@@ -262,3 +262,16 @@ var string = device.serial;
 - Android
 - OSX
 
+## device.isiOSAppOnMac
+
+Is the iOS app running on the Mac desktop? Will only return true on a Mac with an ARM64 processor (Apple Silicon).
+Returns false for all other platforms.
+
+```js
+var boolean = device.isiOSAppOnMac;
+```
+
+### Supported Platforms
+
+- iOS
+

--- a/src/ios/CDVDevice.m
+++ b/src/ios/CDVDevice.m
@@ -119,7 +119,7 @@
     if (@available(iOS 14.0, *)) {
         return [NSProcessInfo processInfo].isiOSAppOnMac;
     } else {
-        // Fallback on earlier versions
+        // Fallback on earlier versions, and platforms
         return false;
     }
 }

--- a/src/ios/CDVDevice.m
+++ b/src/ios/CDVDevice.m
@@ -53,7 +53,7 @@
 {
     NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
     static NSString* UUID_KEY = @"CDVUUID";
-    
+
     // Check user defaults first to maintain backwards compaitibility with previous versions
     // which didn't user identifierForVendor
     NSString* app_uuid = [userDefaults stringForKey:UUID_KEY];
@@ -69,7 +69,7 @@
         [userDefaults setObject:app_uuid forKey:UUID_KEY];
         [userDefaults synchronize];
     }
-    
+
     return app_uuid;
 }
 
@@ -92,7 +92,8 @@
              @"version": [device systemVersion],
              @"uuid": [self uniqueAppInstanceIdentifier:device],
              @"cordova": [[self class] cordovaVersion],
-             @"isVirtual": @([self isVirtual])
+             @"isVirtual": @([self isVirtual]),
+             @"isiOSAppOnMac": @([self isiOSAppOnMac])
              };
 }
 
@@ -110,6 +111,17 @@
     #else
         return false;
     #endif
+}
+
+
+- (BOOL) isiOSAppOnMac
+{
+    if (@available(iOS 14.0, *)) {
+        return [NSProcessInfo processInfo].isiOSAppOnMac;
+    } else {
+        // Fallback on earlier versions
+        return false;
+    }
 }
 
 @end

--- a/src/osx/CDVDevice.m
+++ b/src/osx/CDVDevice.m
@@ -37,7 +37,6 @@
     return modelVersion;
 }
 
-
 - (NSString*) getSerialNr {
     NSString* serialNr;
     io_service_t platformExpert = IOServiceGetMatchingService(kIOMasterPortDefault, IOServiceMatching("IOPlatformExpertDevice"));
@@ -101,6 +100,7 @@
     devProps[@"cordova"] = [[self class] cordovaVersion];
     devProps[@"serial"] = [self getSerialNr];
     devProps[@"isVirtual"] = @NO;
+    devProps[@"isiOSAppOnMac"]: [self isiOSAppOnMac];
 
     NSDictionary* devReturn = [NSDictionary dictionaryWithDictionary:devProps];
     return devReturn;
@@ -108,6 +108,15 @@
 
 + (NSString*) cordovaVersion {
     return CDV_VERSION;
+}
+
++ (BOOL) isiOSAppOnMac {
+    if (@available(iOS 14.0, *)) {
+        return [NSProcessInfo processInfo].isiOSAppOnMac;
+    } else {
+        // Fallback on earlier versions and platforms
+        return false;
+    }
 }
 
 @end

--- a/www/device.js
+++ b/www/device.js
@@ -60,7 +60,10 @@ function Device () {
                 me.cordova = buildLabel;
                 me.model = info.model;
                 me.isVirtual = info.isVirtual;
-                me.isiOSAppOnMac = info.isiOSAppOnMac || false;
+                // isiOSAppOnMac is iOS specific. If defined, it will be appended.
+                if (info.isiOSAppOnMac !== undefined) {
+                    me.isiOSAppOnMac = info.isiOSAppOnMac;
+                }
                 me.manufacturer = info.manufacturer || 'unknown';
                 me.serial = info.serial || 'unknown';
                 channel.onCordovaInfoReady.fire();

--- a/www/device.js
+++ b/www/device.js
@@ -43,6 +43,7 @@ function Device () {
     this.manufacturer = null;
     this.isVirtual = null;
     this.serial = null;
+    this.isiOSAppOnMac = null;
 
     var me = this;
 
@@ -59,6 +60,7 @@ function Device () {
                 me.cordova = buildLabel;
                 me.model = info.model;
                 me.isVirtual = info.isVirtual;
+                me.isiOSAppOnMac = info.isiOSAppOnMac || false;
                 me.manufacturer = info.manufacturer || 'unknown';
                 me.serial = info.serial || 'unknown';
                 channel.onCordovaInfoReady.fire();


### PR DESCRIPTION
# Platforms affected
iOS 14 and up



### Motivation and Context
When running on iOS14, on a Mac that has an Apple Silicon processor (ARM64 instead of Intel), this change allows you to determine this condition using cordova-plugin-device.

This minor change exposes the iOS `isiOSAppOnMac` variable, which is the definitive way to detect that the Cordova iOS app is running on the Mac desktop on a non-Intel processor.

On Cordova apps running on the Apple Silicon desktop, the hardware menu (wifi, clock, cell strength, battery) goes away, and other container changes need to be compensated for, so access to this variable is essential.  This plugin seems like the best place to expose this variable.

### Description
in the iOS NSProcessInfo under iOS 14+, a new system variable has been defined, this change exposes that variable.

    [NSProcessInfo processInfo].isiOSAppOnMac


### Testing
This change works on iOS 14 on macOS Big Sur Version 11.0 Beta 8 (20A5374i) running on an Apple A12Z processor.
The change causes no problem (returns false) on macOS Catalina Version 10.15.6 running on an Intel processor inside an iOS simulator (SE 2nd Gen, 8 Plus 13.3, 11 Pro 14.0, 11 13.3, iPadPro 9.7" 14.0, iPadPro 12" 4th gen 14.0), and on a physical 
iPhone Xs Max running iOS 13.7.
Also no problem on an Android simulator for a Galaxy Tab S5e, and a Galaxy S9+ at API 30, and a Moto G5 plus (Android 8.1.10) physical phone.



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
