### PR TITLE
docs: Update information about device.uuid for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,6 @@ The details of how a UUID is generated are determined by the device manufacturer
 
 ```js
 // Android: Returns a random 64-bit integer (as a string, again!)
-//          The integer is generated on the device's first boot
 //
 // BlackBerry: Returns the PIN number of the device
 //             This is a nine-digit unique integer (as a string, though!)
@@ -161,6 +160,22 @@ The details of how a UUID is generated are determined by the device manufacturer
 // unique to every GSM and UMTS mobile phone.
 var deviceID = device.uuid;
 ```
+
+### Android Quirk
+
+The `uuid` on Android is a 64-bit integer (expressed as a hexadecimal string). The behaviour of this `uuid` is different on two different OS versions-
+
+**For < Android 8.0 (API level 26)**
+
+In versions of the platform lower than Android 8.0, the `uuid` is randomly generated when the user first sets up the device and should remain constant for the lifetime of the user's device.
+
+**For Android 8.0 or higher**
+
+The above behaviour was changed in Android 8.0. Read it in detail [here](https://developer.android.com/about/versions/oreo/android-8.0-changes#privacy-all).
+
+On Android 8.0 and higher versions, the `uuid` will be unique to each combination of app-signing key, user, and device. The value is scoped by signing key and user. The value may change if a factory reset is performed on the device or if an APK signing key changes.
+
+Read more here https://developer.android.com/reference/android/provider/Settings.Secure#ANDROID_ID.
 
 ### iOS Quirk
 


### PR DESCRIPTION
The behaviour of `device.uuid` has been changed since Android 8.0 https://developer.android.com/about/versions/oreo/android-8.0-changes#privacy-all

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

None.

### Motivation and Context

I came to know about this change in Android 8.0 a few hours back so thought of updating the same in this plugin as many developers rely on this `device.uuid`.

### Description

The documentation about `device.uuid` was outdated and its behaviour was changed in Android 8.0. This only changes the documentation in README.md about `device.uuid` behaviour in Android.

### Testing

N/A.

### Checklist

- [ ] ~I've run the tests to see all new and existing tests pass~
- [ ] ~I added automated test coverage as appropriate for this change~
- [ ] ~Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)~
- [ ] ~If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))~
- [x] I've updated the documentation if necessary
