### PR TITLE
fix(osx): rename classes to fix plugin

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -81,7 +81,7 @@
     <platform name="osx">
         <config-file target="config.xml" parent="/*">
             <feature name="Device">
-                <param name="ios-package" value="CDVDevice"/>
+                <param name="ios-package" value="Device"/>
             </feature>
         </config-file>
 

--- a/src/osx/CDVDevice.h
+++ b/src/osx/CDVDevice.h
@@ -19,7 +19,7 @@
 
 #import <Cordova/CDVPlugin.h>
 
-@interface CDVDevice : CDVPlugin
+@interface Device : CDVPlugin
 
 + (NSString*) cordovaVersion;
 

--- a/src/osx/CDVDevice.m
+++ b/src/osx/CDVDevice.m
@@ -23,7 +23,7 @@
 
 #define SYSTEM_VERSION_PLIST    @"/System/Library/CoreServices/SystemVersion.plist"
 
-@implementation CDVDevice
+@implementation Device
 
 - (NSString*) modelVersion {
     size_t size;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
osx


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The plugin is not working with the osx platform right now.

### Description
<!-- Describe your changes in detail -->

This PR changes the name of the class to the same name as the JS classname and this makes this plugin work again.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Added plugin and ran tests on mac

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
