### PR TITLE
chore(electron): fix Electron package.json typo

### DIFF
--- a/src/electron/package.json
+++ b/src/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cordova-plugin-device-electron",
   "version": "1.0.0",
-  "description": "Electron Native Supprot for Cordova Device Plugin",
+  "description": "Electron Native Support for Cordova Device Plugin",
   "main": "index.js",
   "keywords": [
     "cordova",


### PR DESCRIPTION
### Platforms affected

Electron

### Motivation and Context

Fixes a typo in the `description` filed in the Electron `package.json` file.


### Description

`Supprot` => `Support`


### Testing

n/a

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
