### PR TITLE
feat(android): getInfo response to include sdkVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ var isSim = device.isVirtual;
 
 ## device.sdkVersion (Android only)
 
-Will return the Android device's installed SDK version.
+Will return the Android device's SDK version.
 
 ### Supported Platforms
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ function onDeviceReady() {
 - device.manufacturer
 - device.isVirtual
 - device.serial
+- device.sdkVersion (Android only)
 
 ## device.cordova
 
@@ -240,6 +241,10 @@ whether the device is running on a simulator.
 ```js
 var isSim = device.isVirtual;
 ```
+
+## device.sdkVersion (Android only)
+
+Will return the Android device's installed SDK version.
 
 ### Supported Platforms
 

--- a/src/android/Device.java
+++ b/src/android/Device.java
@@ -76,6 +76,7 @@ public class Device extends CordovaPlugin {
             r.put("manufacturer", this.getManufacturer());
 	        r.put("isVirtual", this.isVirtual());
             r.put("serial", this.getSerialNumber());
+            r.put("sdkVersion", this.getSDKVersion());
             callbackContext.success(r);
         }
         else {
@@ -144,9 +145,7 @@ public class Device extends CordovaPlugin {
     }
 
     public String getSDKVersion() {
-        @SuppressWarnings("deprecation")
-        String sdkversion = android.os.Build.VERSION.SDK;
-        return sdkversion;
+        return String.valueOf(android.os.Build.VERSION.SDK_INT);
     }
 
     public String getTimeZoneID() {

--- a/www/device.js
+++ b/www/device.js
@@ -61,6 +61,12 @@ function Device () {
                 me.isVirtual = info.isVirtual;
                 me.manufacturer = info.manufacturer || 'unknown';
                 me.serial = info.serial || 'unknown';
+
+                // SDK Version is Android specific. If defined, it will be appended.
+                if (info.sdkVersion !== undefined) {
+                    me.sdkVersion = info.sdkVersion;
+                }
+
                 channel.onCordovaInfoReady.fire();
             },
             function (e) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Resolves #142

### Description
<!-- Describe your changes in detail -->

Refactored and re-added the getSDKVersion method.

`getInfo` response to contain `sdkVersion` property and added to the `window.device` object.

<img width="786" alt="Device Object" src="https://user-images.githubusercontent.com/1029107/161266651-29524033-787e-4458-ba6b-172871f39fa7.png">

### Testing
<!-- Please describe in detail how you tested your changes. -->

- Build App
- Confirmed `window.device` object
- Called `getInfo`

```javascript
device.getInfo(
    result => {
        console.log("Success Result", result);
    },
    error => {
        console.log("Error", error);
    }
)
```

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
