### PR TITLE
doc(android): clarify documentation and types for sdkVersion field

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,15 +264,11 @@ var isSim = device.isVirtual;
 
 ## device.sdkVersion (Android only)
 
-Will return the Android device's SDK version.
+Get the Android device's SDK version ([SDK_INT](https://developer.android.com/reference/android/os/Build.VERSION#SDK_INT)).
 
 ### Supported Platforms
 
 - Android
-- Browser
-- iOS
-- Windows
-- OS X
 
 ### OS X and Browser Quirk
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -30,6 +30,8 @@ interface Device {
     isVirtual: boolean;
     /** Get the device hardware serial number. */
     serial: string;
+    /** Get the Android device's SDK version. (Android-only) */
+    sdkVersion?: string;
 }
 
 declare var device: Device;


### PR DESCRIPTION
### Platforms affected

Android only


### Motivation and Context

Aligning documentation and types! Nothin' special...


### Description
As above



### Testing
Have confirmed the types work locally for me. No other code changes.



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [X] I've updated the documentation if necessary
