### PR TITLE
fix(electron): use correct engine for 2.1.0 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,11 @@
   "license": "Apache-2.0",
   "engines": {
     "cordovaDependencies": {
-      "3.0.0": {
-        "cordova": ">100",
+      "2.1.0": {
         "cordova-electron": ">=3.0.0"
+      },
+      "3.0.0": {
+        "cordova": ">100"
       }
     }
   },


### PR DESCRIPTION
The electron engine requirement is set for version 3.0.0, which doesn’t exist.
I have added a new entry for 2.1.0 as that’s where electron support was added.