### PR TITLE
docs(android): correct model description

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,13 @@ different across versions of the same product.
 ### Quick Example
 
 ```js
-// Android:    Pixel 4         returns "Pixel 4"
-//             Motorola Droid  returns "voles"
-// Browser:    Google Chrome   returns "Chrome"
-//             Safari          returns "Safari"
-// iOS:     for the iPad Mini, returns iPad2,5; iPhone 5 is iPhone 5,1. See https://www.theiphonewiki.com/wiki/Models
+// Android: Pixel 4             returns "Pixel 4"
+//          Motorola Moto G3    returns "MotoG3"
+// Browser: Google Chrome       returns "Chrome"
+//          Safari              returns "Safari"
+// iOS:     iPad Mini           returns "iPad2,5"
+//          iPhone 5            returns "iPhone5,1"
+// See https://www.theiphonewiki.com/wiki/Models
 // OS X:                        returns "x86_64"
 //
 var model = device.model;

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ different across versions of the same product.
 ### Quick Example
 
 ```js
-// Android:    Nexus One       returns "Passion" (Nexus One code name)
+// Android:    Pixel 4         returns "Pixel 4"
 //             Motorola Droid  returns "voles"
 // Browser:    Google Chrome   returns "Chrome"
 //             Safari          returns "Safari"
@@ -102,7 +102,7 @@ var model = device.model;
 
 ### Android Quirks
 
-- Gets the [product name](https://developer.android.com/reference/android/os/Build.html#PRODUCT) instead of the [model name](https://developer.android.com/reference/android/os/Build.html#MODEL), which is often the production code name. For example, the Nexus One returns `Passion`, and Motorola Droid returns `voles`.
+- Gets the [model name](https://developer.android.com/reference/android/os/Build.html#MODEL).
 
 ### iOS Quirks
 


### PR DESCRIPTION
The android quirk for android is incorrect, model returns the model name, not the product name.