### PR TITLE
WIP feat!: SPM support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,46 @@
+// swift-tools-version:5.5
+
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+import PackageDescription
+
+let package = Package(
+    name: "cordova-plugin-device",
+    platforms: [.iOS(.v11)],
+    products: [
+        .library(
+            name: "cordova-plugin-device",
+            targets: ["cordova-plugin-device"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apache/cordova-ios.git", branch: "master")
+    ],
+    targets: [
+        .target(
+            name: "cordova-plugin-device",
+            dependencies: [
+                .product(name: "CordovaLib", package: "cordova-ios")
+            ],
+            path: "src/",
+            sources: ["ios"],
+            publicHeadersPath: "ios"
+        )
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -29,15 +29,9 @@ let package = Package(
             name: "cordova-plugin-device",
             targets: ["cordova-plugin-device"])
     ],
-    dependencies: [
-        .package(url: "https://github.com/apache/cordova-ios.git", branch: "master")
-    ],
     targets: [
         .target(
             name: "cordova-plugin-device",
-            dependencies: [
-                .product(name: "CordovaLib", package: "cordova-ios")
-            ],
             path: "src/",
             sources: ["ios"],
             publicHeadersPath: "ios"

--- a/plugin.xml
+++ b/plugin.xml
@@ -57,9 +57,6 @@
             </feature>
         </config-file>
 
-        <header-file src="src/ios/CDVDevice.h" />
-        <source-file src="src/ios/CDVDevice.m" />
-
         <resource-file src="src/ios/CDVDevice.bundle" target="CDVDevice.bundle" />
     </platform>
 


### PR DESCRIPTION
This is just a test for converting the plugin to a Swift Package Manager so https://github.com/apache/cordova-ios/pull/1430 can be tested with something.
I had a local copy that didn't have the privacy manifest so I didn't add that to the Package.swift, if we go with this approach we should add it.

It removes `header-file` and `source-file` to prevent `cordova plugin add` from adding those files to the cordova app since they will be added by Swift Package Manager.

Using this approach plugins that want to add Swift Package Manager dependencies will have to be converted to be Swift Package Manager compatible and add dependences as they would to a regular Swift Package instead of relying in a new tag in `plugin.xml`

It's a breaking change because if converted, it will only work in the cordova-ios version that adds SPM plugins support (https://github.com/apache/cordova-ios/pull/1430) since this change removes the `header-file` and `source-file`.
Maybe https://github.com/apache/cordova-ios/pull/1430 could be tweaked to conditionally respect the `header-file` and `source-file`, etc. tags and copy them only if there is no `Package.swift` in the plugin, but would require a ton more work.
