### PR TITLE
chore: Use github links in plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -27,8 +27,8 @@
     <description>Cordova Device Plugin</description>
     <license>Apache 2.0</license>
     <keywords>cordova,device</keywords>
-    <repo>https://git-wip-us.apache.org/repos/asf/cordova-plugin-device.git</repo>
-    <issue>https://issues.apache.org/jira/browse/CB/component/12320648</issue>
+    <repo>https://github.com/apache/cordova-plugin-device</repo>
+    <issue>https://github.com/apache/cordova-plugin-device/issues</issue>
 
     <engines>
         <engine name="cordova-electron" version=">=3.0.0" />


### PR DESCRIPTION
use github links instead of jira and apache git