### PR TITLE
fix(android): use pluginInitialize

### DIFF
--- a/src/android/Device.java
+++ b/src/android/Device.java
@@ -43,12 +43,9 @@ public class Device extends CordovaPlugin {
     /**
      * Sets the context of the Command. This can then be used to do things like
      * get file paths associated with the Activity.
-     *
-     * @param cordova The context of the main Activity.
-     * @param webView The CordovaWebView Cordova is running in.
      */
-    public void initialize(CordovaInterface cordova, CordovaWebView webView) {
-        super.initialize(cordova, webView);
+    @Override
+    protected void pluginInitialize() {
         Device.uuid = getUuid();
     }
 
@@ -60,6 +57,7 @@ public class Device extends CordovaPlugin {
      * @param callbackContext   The callback id used when calling back into JavaScript.
      * @return                  True if the action was valid, false if not.
      */
+    @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
         if ("getDeviceInfo".equals(action)) {
             JSONObject r = new JSONObject();


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Now, `CordovaPlugin.initialize()` is deprecated at Cordova-android@v14.0.0.
refs https://github.com/apache/cordova-android/pull/1771

Following [cordova-docs](https://github.com/apache/cordova-docs/pull/1387), use `pluginInitialize` and remove calling super method.

### Description
<!-- Describe your changes in detail -->

- Override CordovaPlugin.pluginInitialize()
- Remove calling super method

### Testing
<!-- Please describe in detail how you tested your changes. -->

Workflows passed.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
